### PR TITLE
Fix and implement scrapers for missing teams

### DIFF
--- a/data/rosters_2024-25.csv
+++ b/data/rosters_2024-25.csv
@@ -1,0 +1,23 @@
+ncaa_id,team,player_id,name,year,hometown,high_school,previous_school,height,position,jersey,url,season
+147,Clemson,,Indigo Young,Graduate,"Kennesaw, Ga.",,,6-0,Middle Hitter,1,https://www.clemsontigers.com/sports/volleyball/roster/season/2024/indigo-young/,2024-25
+147,Clemson,,Kennedy Wagner,Sophomore,"Valparaiso, Ind.",,,6-0,Pin Attacker,2,https://www.clemsontigers.com/sports/volleyball/roster/season/2024/kennedy-wagner/,2024-25
+147,Clemson,,Maggie Patterson,R. Sophomore,"Gaffney, S.C.",,,5-7,Libero,3,https://www.clemsontigers.com/sports/volleyball/roster/season/2024/maggie-patterson/,2024-25
+147,Clemson,,Lejla Sara Hadžiredžepović,Freshman,"Reykjavík, Iceland",,,6-3,Pin Attacker,5,https://www.clemsontigers.com/sports/volleyball/roster/season/2024/lejla-sara-hadziredzepovic/,2024-25
+147,Clemson,,Katherine Sandt,R. Freshman,"Western Springs, Ill.",,,6-0,Setter,6,https://www.clemsontigers.com/sports/volleyball/roster/season/2024/katherine-sandt/,2024-25
+147,Clemson,,Aźyah Dailey,Senior,"Port Charlotte, Fla.",,,6-2,Pin Attacker,7,https://www.clemsontigers.com/sports/volleyball/roster/season/2024/azyah-dailey/,2024-25
+147,Clemson,,Becca Micelle,Junior,"Naples, Fla.",,,5-3,Libero,8,https://www.clemsontigers.com/sports/volleyball/roster/season/2024/becca-micelle/,2024-25
+147,Clemson,,Ava Hewitt,Sophomore,"Los Angeles, Calif.",,,6-0,Middle Hitter,9,https://www.clemsontigers.com/sports/volleyball/roster/season/2024/ava-hewitt/,2024-25
+147,Clemson,,Addi Rains,Freshman,"Yorktown, Ind.",,,5-5,Libero,11,https://www.clemsontigers.com/sports/volleyball/roster/season/2024/addi-rains/,2024-25
+147,Clemson,,Claire Luoma,Freshman,"Franklin, Wis.",,,5-7,Libero,12,https://www.clemsontigers.com/sports/volleyball/roster/season/2024/claire-luoma/,2024-25
+147,Clemson,,Taylor Bahnub,Freshman,"Dublin, Ohio",,,6-2,Middle Hitter,13,https://www.clemsontigers.com/sports/volleyball/roster/season/2024/taylor-bahnub/,2024-25
+147,Clemson,,Audrey Armbruster,Sophomore,"Cincinnati, Ohio",,,5-11,Setter,14,https://www.clemsontigers.com/sports/volleyball/roster/season/2024/audrey-armbruster/,2024-25
+147,Clemson,,Kate Simington,Sophomore,"Excelsior, Minn.",,,6-4,Middle Hitter,15,https://www.clemsontigers.com/sports/volleyball/roster/season/2024/kate-simington/,2024-25
+147,Clemson,,Devan Taylor,Senior,"Spring, Texas",,,5-9,Libero,16,https://www.clemsontigers.com/sports/volleyball/roster/season/2024/devan-taylor/,2024-25
+147,Clemson,,Kate Hansen,Sophomore,"Weatherford, Texas",,,6-3,Middle Hitter,19,https://www.clemsontigers.com/sports/volleyball/roster/season/2024/kate-hansen/,2024-25
+147,Clemson,,Sophie Catalano,Junior,"Pittsburgh, Pa.",,,5-10,Pin Attacker,20,https://www.clemsontigers.com/sports/volleyball/roster/season/2024/sophie-catalano/,2024-25
+147,Clemson,,Mia Moore,Junior,"Frisco, Texas",,,6-0,Pin Attacker,22,https://www.clemsontigers.com/sports/volleyball/roster/season/2024/mia-moore/,2024-25
+147,Clemson,,Mia McGrath,Junior,"Deerfield, Ill.",,,5-11,Pin Attacker,23,https://www.clemsontigers.com/sports/volleyball/roster/season/2024/mia-mcgrath/,2024-25
+147,Clemson,,Neea-Maria Joki,Freshman,"Tampere, Finland",,,6-0,Pin Attacker,24,https://www.clemsontigers.com/sports/volleyball/roster/season/2024/neea-maria-joki/,2024-25
+147,Clemson,,Katie Hurta,R. Sophomore,"Palos Hills, Ill.",,,6-1,Pin Attacker,25,https://www.clemsontigers.com/sports/volleyball/roster/season/2024/katie-hurta/,2024-25
+147,Clemson,,McKenna Gildon,Sophomore,"Plano, Texas",,,5-10,Libero,28,https://www.clemsontigers.com/sports/volleyball/roster/season/2024/mckenna-gildon/,2024-25
+147,Clemson,,Caroline Sele,R. Sophomore,"San Juan Capistrano, Calif.",,,6-2,Setter,30,https://www.clemsontigers.com/sports/volleyball/roster/season/2024/caroline-sele/,2024-25


### PR DESCRIPTION
Key changes:
1. Fixed routing logic in get_all_rosters() - specific scraper functions
   now checked BEFORE generic JS_TEAMS, preventing routing conflicts

2. Reorganized scraper routing for clarity:
   - Specific function scrapers (BYU, Miami, Clemson, etc.) first
   - Shot-scraper with JS extraction second
   - JS-rendered teams (fetch_url_with_javascript) third
   - URL-based routing fourth
   - Default roster parser last

3. Added 116 previously uncategorized teams to JS_TEAMS list as fallback
   to attempt scraping with JavaScript rendering

4. Added comprehensive comments to TeamConfig.JS_TEAMS explaining its
   purpose and noting teams with specific scrapers are excluded

5. Successfully tested with Clemson (team 147) - scraped all 22 players
   for 2024-25 season

This addresses all 191 teams from data/missing_teams.csv. Many teams will
require proper network access to fully scrape due to shot-scraper/Playwright
dependencies, but the routing infrastructure is now in place.